### PR TITLE
fix: Another attempt at fixing dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,6 @@
 updates:
   - directory: /
-    ignore: []
     package-ecosystem: npm
-    registries:
-      - type: npm
-        url: https://registry.npmjs.org
     schedule:
       interval: weekly
   - directory: /


### PR DESCRIPTION
Remove the `registries`.

Related: #1 #2