### PR TITLE
ci: Dependabot PR settings

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,15 @@
 updates:
-  - directory: /
+  - commit-message:
+      include: scope
+      prefix: core
+    directory: /
     package-ecosystem: npm
     schedule:
       interval: weekly
-  - directory: /
+  - commit-message:
+      include: scope
+      prefix: ci
+    directory: /
     package-ecosystem: github-actions
     schedule:
       interval: weekly


### PR DESCRIPTION
Update Dependabot config to use commitlint compliant PR prefixes.

Specifically:
- NPM (PNPM) related updates => `core`
- Github Action related updates => `ci`