### PR TITLE
Minor maintenance

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -2,15 +2,15 @@ extends:
   - '@commitlint/config-conventional'
 help: |
   **Possible types**:
-  `ci`:       Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs).
-  `core`:     Change build process, tooling or dependencies.
-  `docs`:     Adds or alters documentation.
+  `ci`:       Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs).
+  `core`:     Changes build processes, tooling, dependencies or general project structure.
+  `doc`:      Adds or alters documentation.
   `feat`:     Adds a new feature.
   `fix`:      Solves a bug.
   `perf`:     Improves performance.
-  `refactor`: Rewrites code without feature, performance or bug changes.
-  `revert`:   Changes that reverting other changes
-  `style`:    Improves formatting, white-space.
+  `refactor`: Rewrites code without feature, performance or bug related changes.
+  `revert`:   Changes that reverting other changes.
+  `style`:    Improves formatting, white-space, etc.
   `test`:     Adds or modifies tests.
   `wip`:      Work in progress (temporary commits, which will eventually be rebased or otherwise removed).
 rules:
@@ -22,7 +22,7 @@ rules:
     - always
     - - ci
       - core
-      - docs
+      - doc
       - feat
       - fix
       - perf

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,1 @@
-#!/bin/sh
-
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm exec lint-staged


### PR DESCRIPTION
**commitlint**
- Change commit type `docs` to doc`.
- Update commit type descriptions.

**Husky**
- Remove deprecated code.

Related #8