### PR TITLE
fix: Replace dotenv with dotenv-flow

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -23,7 +23,6 @@ ignoreWords:
   - inputmask
   - JSPCA
   - JSPCA's
-  - lintstagedrc
   - lionels
   - lionelslegacyjersey
   - Lucida

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@heroicons/vue": "^2.1.3",
     "@unhead/vue": "^1.9.14",
     "@vueuse/core": "^10.11.0",
-    "dotenv": "^16.4.5",
+    "dotenv-flow": "^4.1.0",
     "vue": "^3.4.29",
     "vue-router": "^4.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       '@vueuse/core':
         specifier: ^10.11.0
         version: 10.11.0(vue@3.4.33(typescript@5.4.5))
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.4.5
+      dotenv-flow:
+        specifier: ^4.1.0
+        version: 4.1.0
       vue:
         specifier: ^3.4.29
         version: 3.4.33(typescript@5.4.5)
@@ -1517,6 +1517,10 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
+
+  dotenv-flow@4.1.0:
+    resolution: {integrity: sha512-0cwP9jpQBQfyHwvE0cRhraZMkdV45TQedA8AAUZMsFzvmLcQyc1HPv+oX0OOYwLFjIlvgVepQ+WuQHbqDaHJZg==}
+    engines: {node: '>= 12.0.0'}
 
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -4679,6 +4683,10 @@ snapshots:
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
+
+  dotenv-flow@4.1.0:
+    dependencies:
+      dotenv: 16.4.5
 
   dotenv@16.4.5: {}
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 import UnheadVite from '@unhead/addons/vite'
 import vue from '@vitejs/plugin-vue'
-import dotenv from 'dotenv'
+import dotenv from 'dotenv-flow'
 import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import vueDevTools from 'vite-plugin-vue-devtools'


### PR DESCRIPTION
Replace [dotenv](https://github.com/motdotla/dotenv) with [dotenv-flow](https://github.com/kerimdzhanov/dotenv-flow) because the former does not implement much behaviour that had been assumed. In particular it does not:

- Automatically look for environment specific files, e.g. .env.production.
- Look for _local_ files, e.g. .env.production.local.

[dotenv-flow](https://github.com/kerimdzhanov/dotenv-flow) is a drop-in replacement that provides this functionality.

**LINKS**

- https://github.com/motdotla/dotenv
- https://github.com/kerimdzhanov/dotenv-flow
