### PR TITLE
fix: Use tarball for branch-name-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@vitejs/plugin-vue": "^5.1.1",
     "@vue/eslint-config-prettier": "^9.0.0",
     "autoprefixer": "^10.4.20",
-    "branch-name-lint": "git+https://github.com/al/branch-name-lint.git#integration/error-handling-issues",
+    "branch-name-lint": "https://codeload.github.com/al/branch-name-lint/tar.gz/integration/error-handling-issues",
     "cspell": "^8.13.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.41)
       branch-name-lint:
-        specifier: git+https://github.com/al/branch-name-lint.git#integration/error-handling-issues
-        version: git+https://git@github.com:al/branch-name-lint.git#22abe8e719ea3aec03b709e94068aa7a880e7a59
+        specifier: https://codeload.github.com/al/branch-name-lint/tar.gz/integration/error-handling-issues
+        version: https://codeload.github.com/al/branch-name-lint/tar.gz/integration/error-handling-issues
       cspell:
         specifier: ^8.13.3
         version: 8.13.3
@@ -1212,8 +1212,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  branch-name-lint@git+https://git@github.com:al/branch-name-lint.git#22abe8e719ea3aec03b709e94068aa7a880e7a59:
-    resolution: {commit: 22abe8e719ea3aec03b709e94068aa7a880e7a59, repo: git@github.com:al/branch-name-lint.git, type: git}
+  branch-name-lint@https://codeload.github.com/al/branch-name-lint/tar.gz/integration/error-handling-issues:
+    resolution: {tarball: https://codeload.github.com/al/branch-name-lint/tar.gz/integration/error-handling-issues}
     version: 2.1.1
     engines: {node: '>=10'}
     hasBin: true
@@ -4359,7 +4359,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  branch-name-lint@git+https://git@github.com:al/branch-name-lint.git#22abe8e719ea3aec03b709e94068aa7a880e7a59:
+  branch-name-lint@https://codeload.github.com/al/branch-name-lint/tar.gz/integration/error-handling-issues:
     dependencies:
       find-up: 5.0.0
       meow: 9.0.0


### PR DESCRIPTION
Explicitly use a tarball URL for the branch-name-lint dependency to avoid issues with PNPM reverting to the git protocol and thus causing authentication issues/complexities in the Github workflows.

Closes #41
